### PR TITLE
Give the interpolation & extrapolation classes state

### DIFF
--- a/stratify/_vinterp.pyx
+++ b/stratify/_vinterp.pyx
@@ -392,7 +392,6 @@ cdef class _PythonExtrapKernel(ExtrapKernel):
         with gil:
             self.extrap_kernel(direction, z_src, fz_src, level, fz_target)
 
-
 cdef class _TestableDirectionExtrapKernel(ExtrapKernel):
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/stratify/tests/performance.py
+++ b/stratify/tests/performance.py
@@ -1,0 +1,25 @@
+"""
+Functions that may be used to measure performance of a component.
+
+"""
+import numpy as np
+import stratify
+
+
+def src_data(shape=(400, 500, 100)):
+    z = np.tile(np.linspace(0, 100, shape[-1]),
+                np.prod(shape[:2])).reshape(shape)
+    fz = np.arange(np.prod(shape)).reshape(shape)
+    return z, fz 
+
+
+def interp_and_extrap(shape,
+                      interp=stratify.INTERPOLATE_LINEAR,
+                      extrap=stratify.EXTRAPOLATE_NEAREST):
+    z, fz = src_data(shape)
+    stratify.interpolate(np.linspace(-20, 120, 50), z, fz,
+                         interpolation=interp, extrapolation=extrap)
+
+
+if __name__ == '__main__':
+    interp_and_extrap(shape=(500, 600, 100))

--- a/stratify/tests/test_vinterp.py
+++ b/stratify/tests/test_vinterp.py
@@ -253,11 +253,31 @@ class Test_EXTRAPOLATE_LINEAR(unittest.TestCase):
 
         msg = (r'Linear extrapolation requires at least 2 '
                r'source points. Got 1.')
-
         with self.assertRaisesRegexp(ValueError, msg):
             stratify.interpolate([1, 3.], [2], [20],
                                  interpolation=interpolation,
                                  extrapolation=extrapolation, rising=True)
+
+
+class Test_custom_extrap_kernel(unittest.TestCase):
+    class my_kernel(vinterp._PythonExtrapKernel):
+        def __init__(self, *args, **kwargs):
+            self.wibble = 'blah'
+            super(Test_custom_extrap_kernel.my_kernel, self).__init__(*args, **kwargs)
+
+        def prepare_fn(self, *args):
+            print('called me!')
+            raise ValueError()
+
+    def test(self):
+        interpolation = vinterp._TestableIndexInterpKernel()
+        extrapolation = Test_custom_extrap_kernel.my_kernel()
+
+        stratify.interpolate([1, 3.], [1, 2], [10, 20],
+                             interpolation=interpolation,
+                             extrapolation=extrapolation, rising=True)
+        print(extrapolation.wibble)
+
 
 
 class Test__Interpolator(unittest.TestCase):

--- a/stratify/tests/test_vinterp.py
+++ b/stratify/tests/test_vinterp.py
@@ -262,22 +262,20 @@ class Test_EXTRAPOLATE_LINEAR(unittest.TestCase):
 class Test_custom_extrap_kernel(unittest.TestCase):
     class my_kernel(vinterp._PythonExtrapKernel):
         def __init__(self, *args, **kwargs):
-            self.wibble = 'blah'
             super(Test_custom_extrap_kernel.my_kernel, self).__init__(*args, **kwargs)
 
-        def prepare_fn(self, *args):
-            print('called me!')
-            raise ValueError()
+        def extrap_kernel(self, direction, z_src, fz_src, level,
+                          output_array):
+            output_array[:] = -10
 
     def test(self):
         interpolation = vinterp._TestableIndexInterpKernel()
         extrapolation = Test_custom_extrap_kernel.my_kernel()
 
-        stratify.interpolate([1, 3.], [1, 2], [10, 20],
-                             interpolation=interpolation,
-                             extrapolation=extrapolation, rising=True)
-        print(extrapolation.wibble)
-
+        r = stratify.interpolate([1, 3.], [1, 2], [10, 20],
+                                 interpolation=interpolation,
+                                 extrapolation=extrapolation, rising=True)
+        assert_array_equal(r, [0, -10])
 
 
 class Test__Interpolator(unittest.TestCase):


### PR DESCRIPTION
In this PR I make no functional change to the interpolators/extrapolators (as can be seen by the tests not changing). Instead, I have inlined some of the disparate code so that we have Interpolation and Extrapolation classes. The huge advantage to this is that we can potentially have state within these classes, as well as adding custom validation of expected inputs etc.

Having measured this very mildly, it appears there may be a small impact in performance, but it is a price I think is worth paying for the added flexibility/readability this affords.

Before:
```
time python performance.py 

real	0m3.472s
```

After:
```
time python performance.py 

real	0m3.652s
```

I'm taking these with a pinch of salt as my machine is under heavy load, and there is a reasonably large variability in both. In summary - I'm not unduly worried about the performance impact.