### PR TITLE
Fix installation via setup.py and pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-# Include the license file
 include LICENSE
-
+include README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools
+setuptools>=18.0
 cython
 numpy

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from distutils.command.sdist import sdist as _sdist
 import glob
 import os
-
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 PACKAGE_NAME = 'stratify'
 PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+CYTHON_DIRECTIVES = {'linetrace': True, 'binding': True}
 
 try:
     # Detect if Cython is available. Where it is, use it, otherwise fall back
@@ -40,7 +41,7 @@ for source_file in glob.glob('{}/*{}'.format(PACKAGE_NAME, source_suffix)):
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    extensions = cythonize(extensions)
+    extensions = cythonize(extensions, compiler_directives=CYTHON_DIRECTIVES)
 
 
 class SDist(_sdist):
@@ -48,7 +49,7 @@ class SDist(_sdist):
     # an install dependency.
     def run(self):
         from Cython.Build import cythonize
-        cythonize(extensions)
+        cythonize(extensions, compiler_directives=CYTHON_DIRECTIVES)
         _sdist.run(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,16 @@ CYTHON_DIRECTIVES = {'linetrace': True, 'binding': True}
 try:
     # Detect if Cython is available. Where it is, use it, otherwise fall back
     # to C source included with source distribution.
-    import Cython
-    USE_CYTHON = True
+    from Cython.Build import cythonize
 except ImportError:
-    USE_CYTHON = False
+    cythonize = None
 
-source_suffix = '.pyx' if USE_CYTHON else '.c'
+source_suffix = '.pyx' if cythonize else '.c'
 extension_kwargs = {}
 cython_coverage_enabled = os.environ.get('CYTHON_COVERAGE', None)
-if USE_CYTHON and cython_coverage_enabled:
+if cythonize and cython_coverage_enabled:
     extension_kwargs.update({'define_macros': [('CYTHON_TRACE_NOGIL', '1')]})
-if USE_CYTHON:
+if cythonize:
     # Cython requires numpy include headers
     import numpy as np
     extension_kwargs.update({'include_dirs': [np.get_include()]})
@@ -38,8 +37,7 @@ for source_file in glob.glob('{}/*{}'.format(PACKAGE_NAME, source_suffix)):
                       PACKAGE_NAME, source_file_nosuf, source_suffix)],
                   **extension_kwargs))
 
-if USE_CYTHON:
-    from Cython.Build import cythonize
+if cythonize:
     extensions = cythonize(extensions, compiler_directives=CYTHON_DIRECTIVES)
 
 
@@ -47,7 +45,6 @@ class SDist(_sdist):
     # Source distribution build runs Cython so that Cython is not needed as
     # an install dependency.
     def run(self):
-        from Cython.Build import cythonize
         cythonize(extensions, compiler_directives=CYTHON_DIRECTIVES)
         _sdist.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,82 @@
 from __future__ import absolute_import, division, print_function
 
-from setuptools import setup, find_packages, Extension
+from distutils.command.sdist import sdist as _sdist
+import glob
 import os
 
-import numpy as np
+from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 
-from Cython.Build import cythonize
+PACKAGE_NAME = 'stratify'
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
 
+try:
+    # Detect if Cython is available. Where it is, use it, otherwise fall back
+    # to C source included with source distribution.
+    import Cython
+    USE_CYTHON = True
+except ImportError:
+    USE_CYTHON = False
 
-NAME = 'stratify'
-DIR = os.path.abspath(os.path.dirname(__file__))
-
-extension_kwargs = {'include_dirs': [np.get_include()]}
+source_suffix = '.pyx' if USE_CYTHON else '.c'
+extension_kwargs = {}
 cython_coverage_enabled = os.environ.get('CYTHON_COVERAGE', None)
-if cython_coverage_enabled:
+if USE_CYTHON and cython_coverage_enabled:
     extension_kwargs.update({'define_macros': [('CYTHON_TRACE_NOGIL', '1')]})
+if USE_CYTHON:
+    # Cython requires numpy include headers
+    import numpy as np
+    extension_kwargs.update({'include_dirs': [np.get_include()]})
 
-extensions = [Extension('{}._vinterp'.format(NAME),
-                        [os.path.join(NAME, '_vinterp.pyx')],
-                        **extension_kwargs),
-              Extension('{}._conservative'.format(NAME),
-                        [os.path.join(NAME, '_conservative.pyx')],
-                        **extension_kwargs)]
+extensions = []
+cmdclass = {}
+for source_file in glob.glob('{}/*{}'.format(PACKAGE_NAME, source_suffix)):
+    source_file_nosuf, _ = os.path.splitext(os.path.basename(source_file))
+    extensions.append(
+        Extension('{}.{}'.format(PACKAGE_NAME, source_file_nosuf),
+                  sources=['{}/{}{}'.format(
+                      PACKAGE_NAME, source_file_nosuf, source_suffix)],
+                  **extension_kwargs))
+
+if USE_CYTHON:
+    from Cython.Build import cythonize
+    extensions = cythonize(extensions)
+
+
+class SDist(_sdist):
+    # Source distribution build runs Cython so that Cython is not needed as
+    # an install dependency.
+    def run(self):
+        from Cython.Build import cythonize
+        cythonize(extensions)
+        _sdist.run(self)
+
+
+cmdclass['sdist'] = SDist
+
+
+def numpy_build_ext(pars):
+    # Delay numpy import so that setup.py can be run without numpy already
+    # being installed.
+    class NumpyBuildExt(_build_ext):
+        def finalize_options(self):
+            _build_ext.finalize_options(self)
+            __builtins__.__NUMPY_SETUP__ = False
+            import numpy
+            self.include_dirs.append(numpy.get_include())
+
+    return NumpyBuildExt(pars)
+
+
+cmdclass['build_ext'] = numpy_build_ext
+
 
 def extract_version():
     version = None
-    fname = os.path.join(DIR, NAME, '__init__.py')
+    fname = os.path.join(PACKAGE_DIR, PACKAGE_NAME, '__init__.py')
     with open(fname) as fd:
         for line in fd:
-            if (line.startswith('__version__')):
+            if line.startswith('__version__'):
                 _, version = line.split('=')
                 version = version.strip()[1:-1]  # Remove quotations
                 break
@@ -36,13 +84,14 @@ def extract_version():
 
 
 setup_args = dict(
-    name=NAME,
+    name=PACKAGE_NAME,
     description=('Vectorized interpolators that are especially useful for '
                  'Nd vertical interpolation/stratification of atmospheric '
                  'and oceanographic datasets'),
+    author='UK Met Office',
+    author_email='scitools-iris-dev@googlegroups.com',
+    url='https://github.com/SciTools-incubator/python-stratify',
     version=extract_version(),
-    ext_modules=cythonize(extensions, compiler_directives={'linetrace': True,
-                                                           'binding': True}),
     packages=find_packages(),
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -62,7 +111,11 @@ setup_args = dict(
         'Topic :: Scientific/Engineering :: GIS',
     ],
     extras_require={'test': ['nose']},
-    test_suite='{}.tests'.format(NAME),
+    setup_requires=['setuptools>=18.0', 'numpy'],
+    install_requires=['numpy'],
+    ext_modules=extensions,
+    cmdclass=cmdclass,
+    test_suite='{}.tests'.format(PACKAGE_NAME),
     zip_safe=False,
 )
 


### PR DESCRIPTION
The main change here is to avoid upfront imports of Cython and Numpy in `setup.py` which will fail because these may not be installed when code in `setup.py` is run.

The [Cython documentation](http://docs.cython.org/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules) recommends including generated C source with source distribution packages, so the `python setup.py sdist` command runs cythonize and includes this into the tar.gz package. The readme file is also pulled in via the manifest as this is recommended when running `sdist`.

Some additional metadata has been added similar to what's specified in other SciTools packages in order to quieten warnings about this being missing - happy to change what's included here if it's not appropriate for this package.