### PR TITLE
Fix installation via setup.py and pip (take 2)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include pyproject.toml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-# Include the license file
 include LICENSE
-
+include README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=18.0", "wheel", "numpy", "Cython"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [build-system]
-requires = ["setuptools>=18.0", "wheel", "numpy", "Cython"]
+# Defined by PEP 518
+requires = ["setuptools>=40.8.0", "wheel", "numpy", "Cython"]
+# Defined by PEP 517
 build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools>=18.0
+setuptools>=40.8.0
 cython
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools
+setuptools>=18.0
 cython
 numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,7 @@ def extract_version():
 
 # Python 2 is not supported by numpy as of version 1.17
 # but pip will attempt to install/use newer Python 3-only numpy versions.
-if sys.version_info.major < 3:
-    numpy_req = 'numpy<1.17'
-else:
-    numpy_req = 'numpy<2.0'
+numpy_req = 'numpy<1.17' if sys.version_info.major < 3 else 'numpy'
 requirements = ['setuptools>=18.0', numpy_req, 'Cython']
 
 extension_kwargs = {}

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,88 @@
 from __future__ import absolute_import, division, print_function
 
-from setuptools import setup, find_packages, Extension
+import glob
 import os
+import sys
+from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 
-import numpy as np
+# Python 2 has a different name for builtins.
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
 
-from Cython.Build import cythonize
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    print('Warning: Cython is not available - '
+          'will be unable to build stratify extensions')
+    cythonize = None
+
+PACKAGE_NAME = 'stratify'
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+CMDS_NOCYTHONIZE = ['clean', 'sdist']
 
 
-NAME = 'stratify'
-DIR = os.path.abspath(os.path.dirname(__file__))
+class NumpyBuildExt(_build_ext):
+    # Delay numpy import so that setup.py can be run without numpy already
+    # being installed.
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        builtins.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
-extension_kwargs = {'include_dirs': [np.get_include()]}
-cython_coverage_enabled = os.environ.get('CYTHON_COVERAGE', None)
-if cython_coverage_enabled:
-    extension_kwargs.update({'define_macros': [('CYTHON_TRACE_NOGIL', '1')]})
-
-extensions = [Extension('{}._vinterp'.format(NAME),
-                        [os.path.join(NAME, '_vinterp.pyx')],
-                        **extension_kwargs),
-              Extension('{}._conservative'.format(NAME),
-                        [os.path.join(NAME, '_conservative.pyx')],
-                        **extension_kwargs)]
 
 def extract_version():
     version = None
-    fname = os.path.join(DIR, NAME, '__init__.py')
+    fname = os.path.join(PACKAGE_DIR, PACKAGE_NAME, '__init__.py')
     with open(fname) as fd:
         for line in fd:
-            if (line.startswith('__version__')):
+            if line.startswith('__version__'):
                 _, version = line.split('=')
                 version = version.strip()[1:-1]  # Remove quotations
                 break
     return version
 
 
+# Python 2 is not supported by numpy as of version 1.17
+# but pip will attempt to install/use newer Python 3-only numpy versions.
+if sys.version_info.major < 3:
+    numpy_req = 'numpy<1.17'
+else:
+    numpy_req = 'numpy<2.0'
+requirements = ['setuptools>=18.0', numpy_req, 'Cython']
+
+extension_kwargs = {}
+cython_directives = {'binding': True}
+cython_coverage_enabled = os.environ.get('CYTHON_COVERAGE', None)
+if cythonize and cython_coverage_enabled:
+    extension_kwargs.update({'define_macros': [('CYTHON_TRACE_NOGIL', '1')]})
+    cython_directives.update({'linetrace': True})
+
+extensions = []
+for source_file in glob.glob('{}/*.pyx'.format(PACKAGE_NAME)):
+    source_file_nosuf, _ = os.path.splitext(os.path.basename(source_file))
+    extensions.append(
+        Extension('{}.{}'.format(PACKAGE_NAME, source_file_nosuf),
+                  sources=[source_file], **extension_kwargs))
+
+if cythonize and not any([arg in CMDS_NOCYTHONIZE for arg in sys.argv]):
+    extensions = cythonize(extensions, compiler_directives=cython_directives)
+
+
 setup_args = dict(
-    name=NAME,
+    name=PACKAGE_NAME,
     description=('Vectorized interpolators that are especially useful for '
                  'Nd vertical interpolation/stratification of atmospheric '
                  'and oceanographic datasets'),
+    author='UK Met Office',
+    author_email='scitools-iris-dev@googlegroups.com',
+    url='https://github.com/SciTools-incubator/python-stratify',
     version=extract_version(),
-    ext_modules=cythonize(extensions, compiler_directives={'linetrace': True,
-                                                           'binding': True}),
+    cmdclass={'build_ext': NumpyBuildExt},
+    ext_modules=extensions,
     packages=find_packages(),
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -56,13 +96,16 @@ setup_args = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: GIS',
     ],
     extras_require={'test': ['nose']},
-    test_suite='{}.tests'.format(NAME),
+    setup_requires=requirements,
+    install_requires=requirements,
+    test_suite='{}.tests'.format(PACKAGE_NAME),
     zip_safe=False,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def extract_version():
 # Python 2 is not supported by numpy as of version 1.17
 # but pip will attempt to install/use newer Python 3-only numpy versions.
 numpy_req = 'numpy<1.17' if sys.version_info.major < 3 else 'numpy'
-requirements = ['setuptools>=18.0', numpy_req, 'Cython']
+requirements = ['setuptools>=40.8.0', numpy_req, 'Cython']
 
 extension_kwargs = {}
 cython_directives = {'binding': True}


### PR DESCRIPTION
Take two of pull request #27.

Cython and numpy are both listed as requirements now, but `setup.py` should be runnable without them installed so that tools like `pip` can discover the dependencies (if not already discovered via pyproject.toml) and install them.
