### PR TITLE
Address numpy future warnings in stratify.interpolate

### DIFF
--- a/stratify/_vinterp.pyx
+++ b/stratify/_vinterp.pyx
@@ -539,7 +539,7 @@ cdef class _Interpolation(object):
         z_src = np.array(z_src, dtype=np.float64)
         fz_src = np.array(fz_src)
         #: The result data dtype.
-        if np.issubdtype(fz_src.dtype, int):
+        if np.issubdtype(fz_src.dtype, np.signedinteger):
             self._target_dtype = np.dtype('f8')
         else:
             self._target_dtype = fz_src.dtype
@@ -633,7 +633,7 @@ cdef class _Interpolation(object):
                                  'the interpolation axis.')
             z_src_indexer = [0] * z_src.ndim
             z_src_indexer[zp_axis] = slice(0, 2)
-            first_two = z_src[z_src_indexer]
+            first_two = z_src[tuple(z_src_indexer)]
             rising = first_two[0] <= first_two[1]
 
         self.rising = bool(rising)


### PR DESCRIPTION
When using stratify interpolate, or when running the unit tests for this module, numpy raises two Future warnings relating to integer type comparison and indexing an array with a non-tuple sequence. This PR addresses these two issues to get rid of these warnings.

The integer type has been explicitly specified as np.signedinteger which was the previously implied behaviour (I think), and all unit tests pass. I have also repeated the unit tests within IMPROVER which makes use of this functionality and these pass as well.

We would appreciate getting rid of these warnings at source rather than suppressing them.