### PR TITLE
bump version to 0.2.dev0

### DIFF
--- a/stratify/__init__.py
+++ b/stratify/__init__.py
@@ -8,4 +8,4 @@ from ._vinterp import (interpolate, interp_schemes,  # noqa: F401
 from ._bounded_vinterp import interpolate_conservative  # noqa: F401
 
 
-__version__ = '0.1.1'
+__version__ = '0.2.dev0'


### PR DESCRIPTION
Reset the `__version__` back to `0.2.dev0`, after tagging release [v0.1.1](https://github.com/SciTools-incubator/python-stratify/releases/tag/v0.1.1).