### PR TITLE
Use raw strings to avoid invalid escape sequences

### DIFF
--- a/stratify/tests/test_bounded_vinterp.py
+++ b/stratify/tests/test_bounded_vinterp.py
@@ -172,7 +172,7 @@ class TestExceptions(unittest.TestCase):
 
         msg = ('Expecting the shape of the source and target levels except '
                'the axis of interpolation to be identical.  '
-               "\('-', 4, 2\) != \(2, 5, 2\)")
+               r"\('-', 4, 2\) != \(2, 5, 2\)")
         with self.assertRaisesRegexp(ValueError, msg):
             bounded_vinterp.interpolate_conservative(target_bounds,
                                                      source_bounds, data,
@@ -185,7 +185,7 @@ class TestExceptions(unittest.TestCase):
         data = np.zeros((3, 4))
 
         msg = ('The provided data is not of compatible shape with the '
-               "provided source bounds. \('-', 3, 4\) != \(2, 4\)")
+               r"provided source bounds. \('-', 3, 4\) != \(2, 4\)")
         with self.assertRaisesRegexp(ValueError, msg):
             bounded_vinterp.interpolate_conservative(target_bounds,
                                                      source_bounds, data,
@@ -198,7 +198,7 @@ class TestExceptions(unittest.TestCase):
         target_bounds = np.zeros((4, 4, 4))
         data = np.zeros((3, 4))
 
-        msg = 'Unexpected source and target bounds shape. shape\[-1\] != 2'
+        msg = r'Unexpected source and target bounds shape. shape\[-1\] != 2'
         with self.assertRaisesRegexp(ValueError, msg):
             bounded_vinterp.interpolate_conservative(target_bounds,
                                                      source_bounds, data,

--- a/stratify/tests/test_vinterp.py
+++ b/stratify/tests/test_vinterp.py
@@ -379,7 +379,7 @@ class Test_Interpolation(unittest.TestCase):
         z_src = np.empty((3, 4, 5))
         fz_src = np.empty((2, 3, 4, 5))
         emsg = ('z_target and z_src have different shapes, '
-                'got \(3, :, 6\) != \(3, :, 5\)')
+                r'got \(3, :, 6\) != \(3, :, 5\)')
         with self.assertRaisesRegexp(ValueError, emsg):
             vinterp._Interpolation(z_target, z_src, fz_src, axis=2)
 


### PR DESCRIPTION
I noticed a `SyntaxWarning` (not yet an error) when trying to run the tests with the Python 3.8 beta build. While 3.8 is still in beta, this does indeed appear to be a potential problem, and easy to avoid by using raw strings.