### PR TITLE
reinstate .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+#
+# .coveragerc to control coverage.py
+#
+
+[run]
+branch = True
+include =
+    stratify/*
+omit = 
+    stratify/tests/*
+    setup.py
+plugins = Cython.Coverage
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:


### PR DESCRIPTION
This PR reinstates the `.coveragerc` file that I accidentally on purpose purged in #41 :relaxed: 

Hopefully this will reinstate `codecov` test coverage metrics of `cython` .pyx files :crossed_fingers: 